### PR TITLE
Fix for Maven warnings and failing DoubleArrayTrieTest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
+				<version>2.3.2</version>
 				<inherited>true</inherited>
 				<configuration>
 					<source>1.6</source>
@@ -76,6 +77,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>exec-maven-plugin</artifactId>
+				<version>1.2.1</version>
 				<executions>
 					<execution>
 						<id>compile-dictionary</id>

--- a/src/test/java/org/atilika/kuromoji/trie/DoubleArrayTrieTest.java
+++ b/src/test/java/org/atilika/kuromoji/trie/DoubleArrayTrieTest.java
@@ -62,9 +62,9 @@ public class DoubleArrayTrieTest {
 		dir.deleteOnExit();
 		for(File file : dir.listFiles()) {
 			file.deleteOnExit();
-		}
-		
-		assertTrue(dir.length() > 0);
+		}		
+
+		assertTrue(dir.list().length > 0);
 		
 	}
 	


### PR DESCRIPTION
Trivial changes

Added version numbers to maven-compiler-plugin and exec-maven plugin in POM.xml so Maven warnings will not be generated.

Small change to test in DoubleArrayTrieTest so it will pass.
