### PR TITLE
Small changes to reduce dictionary compilation memory usage a little …

### DIFF
--- a/kuromoji-common/src/main/java/com/atilika/kuromoji/compile/AbstractDictionaryCompiler.java
+++ b/kuromoji-common/src/main/java/com/atilika/kuromoji/compile/AbstractDictionaryCompiler.java
@@ -39,6 +39,12 @@ public abstract class AbstractDictionaryCompiler {
     private void buildTokenInfoDictionary(String inputDirname, String outputDirname, String encoding, boolean compactTrie) throws IOException {
         ProgressLog.begin("compiling tokeninfo dict");
         AbstractTokenInfoDictionaryCompiler tokenInfoCompiler = getTokenInfoDictionaryCompiler(encoding);
+
+        ProgressLog.println("analyzing dictionary features");
+        tokenInfoCompiler.analyzeTokenInfo(
+            tokenInfoCompiler.combinedSequentialFileInputStream(new File(inputDirname))
+        );
+        ProgressLog.println("reading tokeninfo");
         tokenInfoCompiler.readTokenInfo(
             tokenInfoCompiler.combinedSequentialFileInputStream(new File(inputDirname))
         );

--- a/kuromoji-common/src/main/java/com/atilika/kuromoji/compile/AbstractTokenInfoDictionaryCompiler.java
+++ b/kuromoji-common/src/main/java/com/atilika/kuromoji/compile/AbstractTokenInfoDictionaryCompiler.java
@@ -48,51 +48,38 @@ public abstract class AbstractTokenInfoDictionaryCompiler<T extends AbstractDict
 
     private String encoding;
 
-    private List<GenericDictionaryEntry> entries = new ArrayList<>();
-
     private List<BufferEntry> bufferEntries = new ArrayList<>();
-
     protected FeatureInfoMap posInfo = new FeatureInfoMap();
-
-    protected FeatureInfoMap otherInfo = new FeatureInfoMap();;
-
+    protected FeatureInfoMap otherInfo = new FeatureInfoMap();
     private List<String> surfaces = new ArrayList<>();
-
     protected WordIdMap wordIdMap = new WordIdMap();
 
     public AbstractTokenInfoDictionaryCompiler(String encoding) {
         this.encoding = encoding;
     }
 
-    public void readTokenInfo(InputStream input) throws IOException {
+    public void analyzeTokenInfo(InputStream input) throws IOException {
         BufferedReader reader = new BufferedReader(new InputStreamReader(input, encoding));
         String line;
 
         while ((line = reader.readLine()) != null) {
             T entry = parse(line);
 
-            GenericDictionaryEntry genericEntry = generateGenericDictionaryEntry(entry);
-            entries.add(genericEntry);
-        }
-    }
+            GenericDictionaryEntry dictionaryEntry = generateGenericDictionaryEntry(entry);
 
-    protected abstract GenericDictionaryEntry generateGenericDictionaryEntry(T entry);
-
-    protected abstract T parse(String line);
-
-    @Override
-    public void compile() throws IOException {
-        generateBufferEntries();
-    }
-
-    public void generateBufferEntries() {
-        for (GenericDictionaryEntry dictionaryEntry : entries) {
             posInfo.mapFeatures(dictionaryEntry.getPosFeatures());
         }
+    }
 
+    public void readTokenInfo(InputStream input) throws IOException {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(input, encoding));
+        String line;
         int entryCount = posInfo.getEntryCount();
 
-        for (GenericDictionaryEntry dictionaryEntry : entries) {
+        while ((line = reader.readLine()) != null) {
+            T entry = parse(line);
+
+            GenericDictionaryEntry dictionaryEntry = generateGenericDictionaryEntry(entry);
 
             short leftId = dictionaryEntry.getLeftId();
             short rightId = dictionaryEntry.getRightId();
@@ -125,6 +112,16 @@ public abstract class AbstractTokenInfoDictionaryCompiler<T extends AbstractDict
             surfaces.add(dictionaryEntry.getSurface());
         }
     }
+
+    protected abstract GenericDictionaryEntry generateGenericDictionaryEntry(T entry);
+
+    protected abstract T parse(String line);
+
+    @Override
+    public void compile() throws IOException {
+
+    }
+
     private boolean entriesFitInAByte(int entryCount) {
         return entryCount <= 0xff;
     }

--- a/kuromoji-common/src/main/java/com/atilika/kuromoji/compile/ProgressLog.java
+++ b/kuromoji-common/src/main/java/com/atilika/kuromoji/compile/ProgressLog.java
@@ -19,15 +19,17 @@ package com.atilika.kuromoji.compile;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Simple progress logger
  */
 public class ProgressLog {
-
     private static int indent = 0;
     private static boolean atEOL = false;
     private static DateFormat dateFormat = new SimpleDateFormat("HH:mm:ss");
+    private static Map<Integer, Long> startTimes = new HashMap<Integer, Long>();
 
     public static void begin(String message) {
         newLine();
@@ -35,12 +37,14 @@ public class ProgressLog {
         System.out.flush();
         atEOL = true;
         indent++;
+        startTimes.put(indent, System.currentTimeMillis());
     }
 
     public static void end() {
         newLine();
+        Long start = startTimes.get(indent);
         indent = Math.max(0, indent - 1);
-        System.out.println(leader() + "done");
+        System.out.println(leader() + "done" + (start != null ? " [" + ((System.currentTimeMillis() - start) / 1000) + "s]" : ""));
         System.out.flush();
     }
 

--- a/kuromoji-common/src/main/java/com/atilika/kuromoji/trie/DoubleArrayTrie.java
+++ b/kuromoji-common/src/main/java/com/atilika/kuromoji/trie/DoubleArrayTrie.java
@@ -31,6 +31,7 @@ import java.nio.IntBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
+import java.util.List;
 
 public class DoubleArrayTrie {
 
@@ -174,17 +175,16 @@ public class DoubleArrayTrie {
      * @param node
      */
     private void add(int previous, int index, Trie.Node node) {
-        Trie.Node[] children = node.getChildren();    // nodes following current node
 
-        if (node.getChildren().length > 0 && node.hasSinglePath() && node.getChildren()[0].getKey() != TERMINATING_CHARACTER) {    // If node has only one path, put the rest in tail array
+        if (!node.getChildren().isEmpty() && node.hasSinglePath() && node.getChildren().get(0).getKey() != TERMINATING_CHARACTER) {    // If node has only one path, put the rest in tail array
             baseBuffer.put(index, tailIndex);    // current index of tail array
-            addToTail(node.children[0]);
+            addToTail(node.getChildren().get(0));
             checkBuffer.put(index, previous);
             return;    // No more child to process
         }
 
         int startIndex = (compact ? 0 : index);
-        int base = findBase(startIndex, children);
+        int base = findBase(startIndex, node.getChildren());
 
         baseBuffer.put(index, base);
 
@@ -192,7 +192,7 @@ public class DoubleArrayTrie {
             checkBuffer.put(index, previous);    // Set check value
         }
 
-        for (Trie.Node child : children) {    // For each child to double array trie
+        for (Trie.Node child : node.getChildren()) {    // For each child to double array trie
             if (compact) {
                 add(index, base + child.getKey(), child);
             } else {
@@ -284,7 +284,7 @@ public class DoubleArrayTrie {
      * @param nodes
      * @return base value for current node
      */
-    private int findBase(int index, Trie.Node[] nodes) {
+    private int findBase(int index, List<Trie.Node> nodes) {
         int base = baseBuffer.get(index);
         if (base < 0) {
             return base;
@@ -348,10 +348,10 @@ public class DoubleArrayTrie {
             }
             tailBuffer.put(tailIndex++ - TAIL_OFFSET, node.getKey());// set character of current node
 
-            if (node.getChildren().length == 0) { // if it reached the end of input, break.
+            if (node.getChildren().isEmpty()) { // if it reached the end of input, break.
                 break;
             }
-            node = node.getChildren()[0]; // Move to next node
+            node = node.getChildren().get(0); // Move to next node
         }
     }
 }

--- a/kuromoji-common/src/main/java/com/atilika/kuromoji/trie/Trie.java
+++ b/kuromoji-common/src/main/java/com/atilika/kuromoji/trie/Trie.java
@@ -16,6 +16,9 @@
  */
 package com.atilika.kuromoji.trie;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Normal Trie which is used to build DoubleArrayTrie
  */
@@ -41,7 +44,7 @@ public class Trie {
      * @param value String to add to Trie
      */
     public void add(String value) {
-        root.add(value + DoubleArrayTrie.TERMINATING_CHARACTER);
+        root.add(value, true);
     }
 
     /**
@@ -59,7 +62,7 @@ public class Trie {
     public class Node {
         char key; /// key(char) of this node
 
-        Node[] children = new Node[0]; // Array to hold children nodes
+        List<Node> children = new ArrayList<Node>(); // Array to hold children nodes
 
         /**
          * Constructor
@@ -82,12 +85,21 @@ public class Trie {
          * @param value String to add
          */
         public void add(String value) {
+            add(value, false);
+        }
+
+        public void add(String value, boolean terminate) {
             if (value.length() == 0) {
                 return;
             }
 
-            Node node = new Node(value.charAt(0));
-            addChild(node).add(value.substring(1));
+            Node node = addChild(new Node(value.charAt(0)));
+            for (int i = 1; i < value.length(); i++) {
+                node = node.addChild(new Node(value.charAt(i)));
+            }
+            if (terminate && (node != null)) {
+                node.addChild(new Node(DoubleArrayTrie.TERMINATING_CHARACTER));
+            }
         }
 
         /**
@@ -99,10 +111,7 @@ public class Trie {
         public Node addChild(Node newNode) {
             Node child = getChild(newNode.getKey());
             if (child == null) {
-                Node[] newChildren = new Node[children.length + 1];
-                System.arraycopy(children, 0, newChildren, 0, children.length);
-                newChildren[newChildren.length - 1] = newNode;
-                children = newChildren;
+                children.add(newNode);
                 child = newNode;
             }
             return child;
@@ -125,11 +134,11 @@ public class Trie {
          * @return true if it has only single path. false if it has multiple path.
          */
         public boolean hasSinglePath() {
-            switch (children.length) {
+            switch (children.size()) {
                 case 0:
                     return true;
                 case 1:
-                    return children[0].hasSinglePath();
+                    return children.get(0).hasSinglePath();
                 default:
                     return false;
             }
@@ -140,7 +149,7 @@ public class Trie {
          *
          * @return Array of children nodes
          */
-        public Node[] getChildren() {
+        public List<Node> getChildren() {
             return children;
         }
 

--- a/kuromoji-common/src/test/java/com/atilika/kuromoji/trie/NodeTest.java
+++ b/kuromoji-common/src/test/java/com/atilika/kuromoji/trie/NodeTest.java
@@ -23,139 +23,139 @@ import static org.junit.Assert.assertEquals;
 
 public class NodeTest {
 
-	@BeforeClass
-	public static void setUpBeforeClass() throws Exception {
-	}
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+    }
 
-	@Test
-	public void testNode() {
-		Trie trie = new Trie();
-		
-		Trie.Node node = trie.new Node('!');
-		assertEquals('!', node.getKey());
+    @Test
+    public void testNode() {
+        Trie trie = new Trie();
 
-		node = trie.new Node('1');
-		assertEquals('1', node.getKey());
+        Trie.Node node = trie.new Node('!');
+        assertEquals('!', node.getKey());
 
-		node = trie.new Node('a');
-		assertEquals('a', node.getKey());
-		
-		node = trie.new Node('！');
-		assertEquals('！', node.getKey());
+        node = trie.new Node('1');
+        assertEquals('1', node.getKey());
 
-		node = trie.new Node('１');
-		assertEquals('１', node.getKey());
+        node = trie.new Node('a');
+        assertEquals('a', node.getKey());
 
-		node = trie.new Node('あ');
-		assertEquals('あ', node.getKey());
+        node = trie.new Node('！');
+        assertEquals('！', node.getKey());
 
-		node = trie.new Node('漢');
-		assertEquals('漢', node.getKey());		
-		
-	}
+        node = trie.new Node('１');
+        assertEquals('１', node.getKey());
 
-	@Test
-	public void testAddChild() {
-		Trie trie = new Trie();
-		Trie.Node node = trie.new Node('a');
+        node = trie.new Node('あ');
+        assertEquals('あ', node.getKey());
 
-		Trie.Node returnedNode = node.addChild(trie.new Node('b'));
-		assertEquals('b', returnedNode.getKey());
-		assertEquals(1, node.getChildren().length);		
-		assertEquals('b', node.getChildren()[0].getKey());
-		
-		returnedNode = node.addChild(trie.new Node('c'));
-		assertEquals('c', returnedNode.getKey());		
-		assertEquals(2, node.getChildren().length);		
-		assertEquals('c', node.getChildren()[1].getKey());
-	}
+        node = trie.new Node('漢');
+        assertEquals('漢', node.getKey());
 
-	@Test
-	public void testAdd() {
-		Trie trie = new Trie();
+    }
 
-		Trie.Node node = trie.new Node('a');
-		node.add("");
-		assertEquals(0, node.getChildren().length);
-		
-		node = trie.new Node('a');
-		node.add("b");
-		assertEquals(1, node.getChildren().length);
-		assertEquals('b', node.getChildren()[0].getKey());		
+    @Test
+    public void testAddChild() {
+        Trie trie = new Trie();
+        Trie.Node node = trie.new Node('a');
 
-		node = trie.new Node('a');
-		node.add("bc");
-		Trie.Node b = node.getChildren()[0];
-		assertEquals(1, node.getChildren().length);
-		assertEquals('b', b.getKey());		
-		assertEquals(1, b.getChildren().length);
-		Trie.Node c = b.getChildren()[0];
-		assertEquals('c', c.getKey());		
-		assertEquals(0, c.getChildren().length);
+        Trie.Node returnedNode = node.addChild(trie.new Node('b'));
+        assertEquals('b', returnedNode.getKey());
+        assertEquals(1, node.getChildren().size());
+        assertEquals('b', node.getChildren().get(0).getKey());
 
-		node.add("bd");
-		b = node.getChildren()[0];
-		assertEquals(1, node.getChildren().length);
-		assertEquals('b', b.getKey());
-		assertEquals(2, b.getChildren().length);
-		c = b.getChildren()[0];
-		assertEquals('c', c.getKey());		
-		assertEquals(0, c.getChildren().length);
-		Trie.Node d = b.getChildren()[1];
-		assertEquals('d', d.getKey());		
-		assertEquals(0, d.getChildren().length);
-	}
-	
-	
-	@Test
-	public void testGetkey() {
-		Trie trie = new Trie();
+        returnedNode = node.addChild(trie.new Node('c'));
+        assertEquals('c', returnedNode.getKey());
+        assertEquals(2, node.getChildren().size());
+        assertEquals('c', node.getChildren().get(1).getKey());
+    }
 
-		Trie.Node node = trie.new Node('!');
-		assertEquals('!', node.getKey());
+    @Test
+    public void testAdd() {
+        Trie trie = new Trie();
 
-		node = trie.new Node('1');
-		assertEquals('1', node.getKey());
+        Trie.Node node = trie.new Node('a');
+        node.add("");
+        assertEquals(0, node.getChildren().size());
 
-		node = trie.new Node('a');
-		assertEquals('a', node.getKey());
-		
-		node = trie.new Node('！');
-		assertEquals('！', node.getKey());
+        node = trie.new Node('a');
+        node.add("b");
+        assertEquals(1, node.getChildren().size());
+        assertEquals('b', node.getChildren().get(0).getKey());
 
-		node = trie.new Node('１');
-		assertEquals('１', node.getKey());
+        node = trie.new Node('a');
+        node.add("bc");
+        Trie.Node b = node.getChildren().get(0);
+        assertEquals(1, node.getChildren().size());
+        assertEquals('b', b.getKey());
+        assertEquals(1, b.getChildren().size());
+        Trie.Node c = b.getChildren().get(0);
+        assertEquals('c', c.getKey());
+        assertEquals(0, c.getChildren().size());
 
-		node = trie.new Node('あ');
-		assertEquals('あ', node.getKey());
+        node.add("bd");
+        b = node.getChildren().get(0);
+        assertEquals(1, node.getChildren().size());
+        assertEquals('b', b.getKey());
+        assertEquals(2, b.getChildren().size());
+        c = b.getChildren().get(0);
+        assertEquals('c', c.getKey());
+        assertEquals(0, c.getChildren().size());
+        Trie.Node d = b.getChildren().get(1);
+        assertEquals('d', d.getKey());
+        assertEquals(0, d.getChildren().size());
+    }
 
-		node = trie.new Node('漢');
-		assertEquals('漢', node.getKey());		
-	}
-	
-	@Test
-	public void testHasSinglePath() {
-		Trie trie = new Trie();
 
-		Trie.Node node = trie.new Node('a');
-		node.add("bcd");
-		assertEquals(true, node.hasSinglePath());
-		
-		node.add("bce");
-		assertEquals(false, node.hasSinglePath());
-	}
-	
-	@Test
-	public void testGetChildren() {
-		Trie trie = new Trie();
+    @Test
+    public void testGetkey() {
+        Trie trie = new Trie();
 
-		Trie.Node node = trie.new Node('a');
-		node.add("bcd");
-		node.add("bde");
-		node.add("xyz");
-		
-		assertEquals(2, node.getChildren().length);
-		assertEquals('b', node.getChildren()[0].getKey());
-		assertEquals('x', node.getChildren()[1].getKey());
-	}
+        Trie.Node node = trie.new Node('!');
+        assertEquals('!', node.getKey());
+
+        node = trie.new Node('1');
+        assertEquals('1', node.getKey());
+
+        node = trie.new Node('a');
+        assertEquals('a', node.getKey());
+
+        node = trie.new Node('！');
+        assertEquals('！', node.getKey());
+
+        node = trie.new Node('１');
+        assertEquals('１', node.getKey());
+
+        node = trie.new Node('あ');
+        assertEquals('あ', node.getKey());
+
+        node = trie.new Node('漢');
+        assertEquals('漢', node.getKey());
+    }
+
+    @Test
+    public void testHasSinglePath() {
+        Trie trie = new Trie();
+
+        Trie.Node node = trie.new Node('a');
+        node.add("bcd");
+        assertEquals(true, node.hasSinglePath());
+
+        node.add("bce");
+        assertEquals(false, node.hasSinglePath());
+    }
+
+    @Test
+    public void testGetChildren() {
+        Trie trie = new Trie();
+
+        Trie.Node node = trie.new Node('a');
+        node.add("bcd");
+        node.add("bde");
+        node.add("xyz");
+
+        assertEquals(2, node.getChildren().size());
+        assertEquals('b', node.getChildren().get(0).getKey());
+        assertEquals('x', node.getChildren().get(1).getKey());
+    }
 }

--- a/kuromoji-common/src/test/java/com/atilika/kuromoji/trie/TrieTest.java
+++ b/kuromoji-common/src/test/java/com/atilika/kuromoji/trie/TrieTest.java
@@ -40,9 +40,9 @@ public class TrieTest {
         trie.add("bb");
 
         Node rootNode = trie.getRoot();
-        assertEquals(2, rootNode.getChildren().length);
-        assertEquals(2, rootNode.getChildren()[0].getChildren().length);
-        assertEquals(1, rootNode.getChildren()[1].getChildren().length);
+        assertEquals(2, rootNode.getChildren().size());
+        assertEquals(2, rootNode.getChildren().get(0).getChildren().size());
+        assertEquals(1, rootNode.getChildren().get(1).getChildren().size());
     }
 
     @Test
@@ -53,9 +53,9 @@ public class TrieTest {
         trie.add("bb");
 
         Node rootNode = trie.getRoot();
-        assertEquals(2, rootNode.getChildren().length);
-        assertEquals(2, rootNode.getChildren()[0].getChildren().length);
-        assertEquals(1, rootNode.getChildren()[1].getChildren().length);
+        assertEquals(2, rootNode.getChildren().size());
+        assertEquals(2, rootNode.getChildren().get(0).getChildren().size());
+        assertEquals(1, rootNode.getChildren().get(1).getChildren().size());
     }
 
     @Test
@@ -66,8 +66,8 @@ public class TrieTest {
         assertTrue(trie.getRoot().hasSinglePath());
         trie.add("abdfg");
         Node rootNode = trie.getRoot();
-        assertEquals(2, rootNode.getChildren()[0].getChildren()[0].getChildren().length);
-        assertTrue(rootNode.getChildren()[0].getChildren()[0].getChildren()[0].hasSinglePath());
-        assertTrue(rootNode.getChildren()[0].getChildren()[0].getChildren()[1].hasSinglePath());
+        assertEquals(2, rootNode.getChildren().get(0).getChildren().get(0).getChildren().size());
+        assertTrue(rootNode.getChildren().get(0).getChildren().get(0).getChildren().get(0).hasSinglePath());
+        assertTrue(rootNode.getChildren().get(0).getChildren().get(0).getChildren().get(1).hasSinglePath());
     }
 }


### PR DESCRIPTION
…and attempt to keep the memory usage within mvn's default.

* Replaced repeatedly duplicated and tossed Node arrays with a List
* Generate token info in two passes of the source file, rather than load them into memory