### PR TITLE
Tokenizer refactoring

### DIFF
--- a/kuromoji-common/src/main/java/com/atilika/kuromoji/AbstractTokenizer.java
+++ b/kuromoji-common/src/main/java/com/atilika/kuromoji/AbstractTokenizer.java
@@ -64,9 +64,6 @@ public abstract class AbstractTokenizer {
 
     protected EnumMap<ViterbiNode.Type, Dictionary> dictionaryMap = new EnumMap<>(ViterbiNode.Type.class);
 
-    protected AbstractTokenizer() {
-    }
-
     public void configure(Builder builder) {
 
         builder.loadDictionaries();
@@ -229,6 +226,11 @@ public abstract class AbstractTokenizer {
 
         protected ResourceResolver resolver = new ClassLoaderResolver(this.getClass());
 
+        /**
+         * Create Tokenizer instance
+         *
+         * @return Tokenizer
+         */
         public <T extends AbstractTokenizer> T build() {
             return null;
         }

--- a/kuromoji-common/src/main/java/com/atilika/kuromoji/dict/UserDictionary.java
+++ b/kuromoji-common/src/main/java/com/atilika/kuromoji/dict/UserDictionary.java
@@ -61,10 +61,10 @@ public class UserDictionary implements Dictionary {
 
     public UserDictionary(InputStream inputStream,
                           int totalFeatures,
-                          int readingFeauture,
+                          int readingFeature,
                           int partOfSpeechFeature) throws IOException {
         this.totalFeatures = totalFeatures;
-        this.readingFeature = readingFeauture;
+        this.readingFeature = readingFeature;
         this.partOfSpeechFeature = partOfSpeechFeature;
         read(inputStream);
     }

--- a/kuromoji-ipadic/src/main/java/com/atilika/kuromoji/ipadic/Tokenizer.java
+++ b/kuromoji-ipadic/src/main/java/com/atilika/kuromoji/ipadic/Tokenizer.java
@@ -31,6 +31,15 @@ import java.util.ArrayList;
 
 public class Tokenizer extends AbstractTokenizer {
 
+    public Tokenizer() {
+        this(new Builder());
+    }
+
+    public Tokenizer(Builder builder) {
+        configure(builder);
+    }
+
+
     @Override
     protected Token createToken(int offset, ViterbiNode node, int wordId) {
         return new Token(
@@ -128,16 +137,10 @@ public class Tokenizer extends AbstractTokenizer {
             }
         }
 
-        /**
-         * Create Tokenizer instance
-         *
-         * @return Tokenizer
-         */
+
         @Override
         public synchronized Tokenizer build() {
-            Tokenizer tokenizer = new Tokenizer();
-            tokenizer.configure(this);
-            return tokenizer;
+            return new Tokenizer(this);
         }
 
     }

--- a/kuromoji-ipadic/src/main/java/com/atilika/kuromoji/ipadic/Tokenizer.java
+++ b/kuromoji-ipadic/src/main/java/com/atilika/kuromoji/ipadic/Tokenizer.java
@@ -17,108 +17,68 @@
 package com.atilika.kuromoji.ipadic;
 
 import com.atilika.kuromoji.AbstractTokenizer;
-import com.atilika.kuromoji.ClassLoaderResolver;
 import com.atilika.kuromoji.PrefixDecoratorResolver;
-import com.atilika.kuromoji.ResourceResolver;
 import com.atilika.kuromoji.TokenizerRunner;
 import com.atilika.kuromoji.dict.ConnectionCosts;
 import com.atilika.kuromoji.dict.InsertedDictionary;
 import com.atilika.kuromoji.dict.TokenInfoDictionary;
 import com.atilika.kuromoji.dict.UnknownDictionary;
-import com.atilika.kuromoji.dict.UserDictionary;
 import com.atilika.kuromoji.trie.DoubleArrayTrie;
 import com.atilika.kuromoji.viterbi.ViterbiNode;
 
-import java.io.BufferedInputStream;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.List;
 
 public class Tokenizer extends AbstractTokenizer {
 
-    public Tokenizer(Builder builder) {
-        super(
-            builder.doubleArrayTrie,
-            builder.connectionCosts,
-            builder.tokenInfoDictionary,
-            builder.unknownDictionary,
-            builder.userDictionary,
-            builder.insertedDictionary,
-            builder.getMode(),
-            builder.getSplit(),
-            builder.getPenalties()
+    @Override
+    protected Token createToken(int offset, ViterbiNode node, int wordId) {
+        return new Token(
+            wordId,
+            node.getSurfaceForm(),
+            node.getType(),
+            offset + node.getStartIndex(),
+            dictionaryMap.get(node.getType())
         );
     }
 
-    @Override
-    protected Token createToken(int offset, ViterbiNode node, int wordId) {
-        return new Token(wordId, node.getSurfaceForm(), node.getType(), offset + node.getStartIndex(), dictionaryMap.get(node.getType()));
-    }
-
-    private static Tokenizer init(String[] args) throws IOException {
-        Tokenizer tokenizer;
-        if (args.length == 1) {
-            Tokenizer.Mode mode = AbstractTokenizer.Mode.valueOf(args[0].toUpperCase());
-            tokenizer = new Builder().mode(mode).build();
-        } else if (args.length == 2) {
-            AbstractTokenizer.Mode mode = AbstractTokenizer.Mode.valueOf(args[0].toUpperCase());
-            tokenizer = new Builder().mode(mode).userDictionary(args[1]).build();
-        } else {
-            tokenizer = new Builder().build();
-        }
-        return tokenizer;
-    }
-
     public static void main(String[] args) throws IOException {
-        Tokenizer tokenizer = init(args);
+        Tokenizer tokenizer;
+        switch (args.length) {
+            case 1:
+                Tokenizer.Mode mode = AbstractTokenizer.Mode.valueOf(args[0].toUpperCase());
+                tokenizer = new Builder().mode(mode).build();
+                break;
+            case 2:
+                mode = AbstractTokenizer.Mode.valueOf(args[0].toUpperCase());
+                tokenizer = new Builder().mode(mode).userDictionary(args[1]).build();
+                break;
+            default:
+                tokenizer = new Builder().build();
+                break;
+        }
         new TokenizerRunner().run(tokenizer);
     }
 
     /**
      * Builder class used to create Tokenizer instance.
      */
-    public static class Builder {
+    public static class Builder extends AbstractTokenizer.Builder {
 
-        private Mode mode = Mode.NORMAL;
-
-        private boolean split = true;
-
-        private DoubleArrayTrie doubleArrayTrie;
-
-        private ConnectionCosts connectionCosts;
-
-        private TokenInfoDictionary tokenInfoDictionary;
-
-        private UnknownDictionary unknownDictionary;
-
-        private UserDictionary userDictionary = null;
-
-        private InsertedDictionary insertedDictionary;
-
+        /**
+         * ipadic-specific search mode settings
+         */
         private Integer searchModeKanjiLength;
         private Integer searchModeKanjiPenalty;
         private Integer searchModeOtherLength;
         private Integer searchModeOtherPenalty;
 
-
-        /**
-         * The default resource prefix, also configurable via
-         * system property <code>com.atilika.kuromoji.dict.targetdir</code>.
-         */
-        private String defaultPrefix = System.getProperty(
-            DEFAULT_DICT_PREFIX_PROPERTY,
-            DEFAULT_DICT_PREFIX);
-
-        /**
-         * The default resource resolver (relative to this class).
-         */
-        private ResourceResolver resolver = new ClassLoaderResolver(this.getClass());
-
-
         public Builder() {
-
+            totalFeatures = 9;
+            unknownDictionaryTotalFeatures = 9;
+            readingFeature = 7;
+            partOfSpeechFeature = 0;
+            defaultPrefix = System.getProperty(DEFAULT_DICT_PREFIX_PROPERTY, "com/atilika/kuromoji/ipadic/");
         }
 
         /**
@@ -133,36 +93,6 @@ public class Tokenizer extends AbstractTokenizer {
             return this;
         }
 
-        /**
-         * Set user dictionary input stream
-         *
-         * @param userDictionaryInputStream dictionary file as input stream
-         * @return Builder
-         * @throws java.io.IOException
-         */
-        public synchronized Builder userDictionary(InputStream userDictionaryInputStream) throws IOException {
-            this.userDictionary = new UserDictionary(
-                userDictionaryInputStream,
-                9, 7, 0
-            );
-            return this;
-        }
-
-        /**
-         * Set user dictionary path
-         *
-         * @param userDictionaryPath path to dictionary file
-         * @return Builder
-         * @throws IOException
-         * @throws java.io.FileNotFoundException
-         */
-        public synchronized Builder userDictionary(String userDictionaryPath) throws IOException {
-            if (userDictionaryPath != null && !userDictionaryPath.isEmpty()) {
-                this.userDictionary(new BufferedInputStream(new FileInputStream(userDictionaryPath)));
-            }
-            return this;
-        }
-
         public synchronized Builder penalties(int kanjiLength, int kanjiPenalty, int otherLength, int otherPenalty) {
             this.searchModeKanjiLength = kanjiLength;
             this.searchModeKanjiPenalty = kanjiPenalty;
@@ -171,12 +101,18 @@ public class Tokenizer extends AbstractTokenizer {
             return this;
         }
 
-        /**
-         * Create Tokenizer instance
-         *
-         * @return Tokenizer
-         */
-        public synchronized Tokenizer build() {
+        @Override
+        public void loadDictionaries() {
+            if (this.mode != Mode.NORMAL
+                && searchModeKanjiLength != null && searchModeKanjiPenalty != null
+                && searchModeOtherLength != null && searchModeOtherPenalty != null) {
+                penalties = new ArrayList<Integer>();
+                penalties.add(searchModeKanjiLength);
+                penalties.add(searchModeKanjiPenalty);
+                penalties.add(searchModeOtherLength);
+                penalties.add(searchModeOtherPenalty);
+            }
+
             if (defaultPrefix != null) {
                 resolver = new PrefixDecoratorResolver(defaultPrefix, resolver);
             }
@@ -190,31 +126,20 @@ public class Tokenizer extends AbstractTokenizer {
             } catch (Exception ouch) {
                 throw new RuntimeException("Could not load dictionaries.", ouch);
             }
-
-            return new Tokenizer(this);
         }
 
-        public Mode getMode() {
-            return mode;
+        /**
+         * Create Tokenizer instance
+         *
+         * @return Tokenizer
+         */
+        @Override
+        public synchronized Tokenizer build() {
+            Tokenizer tokenizer = new Tokenizer();
+            tokenizer.configure(this);
+            return tokenizer;
         }
 
-        public boolean getSplit() {
-            return split;
-        }
-
-        public List<Integer> getPenalties() {
-            List<Integer> penalties = new ArrayList<>();
-            if (this.mode != Mode.NORMAL
-                && searchModeKanjiLength != null && searchModeKanjiPenalty != null
-                && searchModeOtherLength != null && searchModeOtherPenalty != null) {
-                penalties.add(searchModeKanjiLength);
-                penalties.add(searchModeKanjiPenalty);
-                penalties.add(searchModeOtherLength);
-                penalties.add(searchModeOtherPenalty);
-
-            }
-            return penalties;
-        }
     }
 
 }

--- a/kuromoji-jumandic/src/main/java/com/atilika/kuromoji/jumandic/Tokenizer.java
+++ b/kuromoji-jumandic/src/main/java/com/atilika/kuromoji/jumandic/Tokenizer.java
@@ -18,41 +18,9 @@
 package com.atilika.kuromoji.jumandic;
 
 import com.atilika.kuromoji.AbstractTokenizer;
-import com.atilika.kuromoji.ClassLoaderResolver;
-import com.atilika.kuromoji.PrefixDecoratorResolver;
-import com.atilika.kuromoji.ResourceResolver;
-import com.atilika.kuromoji.TokenizerRunner;
-import com.atilika.kuromoji.dict.ConnectionCosts;
-import com.atilika.kuromoji.dict.InsertedDictionary;
-import com.atilika.kuromoji.dict.TokenInfoDictionary;
-import com.atilika.kuromoji.dict.UnknownDictionary;
-import com.atilika.kuromoji.dict.UserDictionary;
-import com.atilika.kuromoji.trie.DoubleArrayTrie;
 import com.atilika.kuromoji.viterbi.ViterbiNode;
 
-import java.io.BufferedInputStream;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Collections;
-
 public class Tokenizer extends AbstractTokenizer {
-
-    public static final String DEFAULT_DICT_PREFIX = "com/atilika/kuromoji/jumandic/";
-
-    public Tokenizer(Builder builder) {
-        super(
-            builder.doubleArrayTrie,
-            builder.connectionCosts,
-            builder.tokenInfoDictionary,
-            builder.unknownDictionary,
-            builder.userDictionary,
-            builder.insertedDictionary,
-            Mode.NORMAL,
-            true, // split,
-            Collections.EMPTY_LIST
-        );
-    }
 
     @Override
     protected Token createToken(int offset, ViterbiNode node, int wordId) {
@@ -65,75 +33,21 @@ public class Tokenizer extends AbstractTokenizer {
         );
     }
 
-    private static Tokenizer init(String[] args) throws IOException {
-        if (args.length == 1) {
-            return new Builder().userDictionary(args[0]).build();
+    public static class Builder extends AbstractTokenizer.Builder {
+
+        public Builder() {
+            totalFeatures = 7;
+            unknownDictionaryTotalFeatures = 7;
+            readingFeature = 5;
+            partOfSpeechFeature = 0;
+            defaultPrefix = System.getProperty(DEFAULT_DICT_PREFIX_PROPERTY, "com/atilika/kuromoji/jumandic/");
         }
 
-        return new Builder().build();
-    }
-
-    public static void main(String[] args) throws IOException {
-        Tokenizer tokenizer = init(args);
-        new TokenizerRunner().run(tokenizer);
-    }
-
-    public static class Builder {
-
-        private DoubleArrayTrie doubleArrayTrie;
-
-        private ConnectionCosts connectionCosts;
-
-        private TokenInfoDictionary tokenInfoDictionary;
-
-        private UnknownDictionary unknownDictionary;
-
-        private UserDictionary userDictionary = null;
-
-        private InsertedDictionary insertedDictionary;
-
-        private String defaultPrefix = System.getProperty(
-            DEFAULT_DICT_PREFIX_PROPERTY,
-            DEFAULT_DICT_PREFIX);
-
-        private ResourceResolver resolver = new ClassLoaderResolver(this.getClass());
-
-        public synchronized Builder userDictionary(InputStream userDictionaryInputStream) throws IOException {
-            this.userDictionary = new UserDictionary(
-                userDictionaryInputStream,
-                7, 5, 0
-            );
-            return this;
-        }
-
-        public synchronized Builder userDictionary(String userDictionaryPath) throws IOException {
-            if (userDictionaryPath != null && !userDictionaryPath.isEmpty()) {
-                this.userDictionary(new BufferedInputStream(new FileInputStream(userDictionaryPath)));
-            }
-            return this;
-        }
-
-        public synchronized Builder prefix(String resourcePrefix) {
-            this.defaultPrefix = resourcePrefix;
-            return this;
-        }
-
+        @Override
         public synchronized Tokenizer build() {
-            if (defaultPrefix != null) {
-                resolver = new PrefixDecoratorResolver(defaultPrefix, resolver);
-            }
-
-            try {
-                doubleArrayTrie = DoubleArrayTrie.newInstance(resolver);
-                connectionCosts = ConnectionCosts.newInstance(resolver);
-                tokenInfoDictionary = TokenInfoDictionary.newInstance(resolver);
-                unknownDictionary = UnknownDictionary.newInstance(resolver, 7);
-                insertedDictionary = new InsertedDictionary(7);
-            } catch (Exception ouch) {
-                throw new RuntimeException("Could not load dictionaries.", ouch);
-            }
-
-            return new Tokenizer(this);
+            Tokenizer tokenizer = new Tokenizer();
+            tokenizer.configure(this);
+            return tokenizer;
         }
     }
 }

--- a/kuromoji-jumandic/src/main/java/com/atilika/kuromoji/jumandic/Tokenizer.java
+++ b/kuromoji-jumandic/src/main/java/com/atilika/kuromoji/jumandic/Tokenizer.java
@@ -22,6 +22,14 @@ import com.atilika.kuromoji.viterbi.ViterbiNode;
 
 public class Tokenizer extends AbstractTokenizer {
 
+    public Tokenizer() {
+        this(new Builder());
+    }
+
+    public Tokenizer(Builder builder) {
+        configure(builder);
+    }
+
     @Override
     protected Token createToken(int offset, ViterbiNode node, int wordId) {
         return new Token(
@@ -45,9 +53,7 @@ public class Tokenizer extends AbstractTokenizer {
 
         @Override
         public synchronized Tokenizer build() {
-            Tokenizer tokenizer = new Tokenizer();
-            tokenizer.configure(this);
-            return tokenizer;
+            return new Tokenizer(this);
         }
     }
 }

--- a/kuromoji-naist-jdic/src/main/java/com/atilika/kuromoji/naist/jdic/Tokenizer.java
+++ b/kuromoji-naist-jdic/src/main/java/com/atilika/kuromoji/naist/jdic/Tokenizer.java
@@ -22,6 +22,14 @@ import com.atilika.kuromoji.viterbi.ViterbiNode;
 
 public class Tokenizer extends AbstractTokenizer {
 
+    public Tokenizer() {
+        this(new Builder());
+    }
+
+    public Tokenizer(Builder builder) {
+        configure(builder);
+    }
+
     @Override
     protected Token createToken(int offset, ViterbiNode node, int wordId) {
         return new Token(
@@ -45,9 +53,7 @@ public class Tokenizer extends AbstractTokenizer {
 
         @Override
         public synchronized Tokenizer build() {
-            Tokenizer tokenizer = new Tokenizer();
-            tokenizer.configure(this);
-            return tokenizer;
+            return new Tokenizer(this);
         }
 
     }

--- a/kuromoji-naist-jdic/src/main/java/com/atilika/kuromoji/naist/jdic/Tokenizer.java
+++ b/kuromoji-naist-jdic/src/main/java/com/atilika/kuromoji/naist/jdic/Tokenizer.java
@@ -18,41 +18,9 @@
 package com.atilika.kuromoji.naist.jdic;
 
 import com.atilika.kuromoji.AbstractTokenizer;
-import com.atilika.kuromoji.ClassLoaderResolver;
-import com.atilika.kuromoji.PrefixDecoratorResolver;
-import com.atilika.kuromoji.ResourceResolver;
-import com.atilika.kuromoji.TokenizerRunner;
-import com.atilika.kuromoji.dict.ConnectionCosts;
-import com.atilika.kuromoji.dict.InsertedDictionary;
-import com.atilika.kuromoji.dict.TokenInfoDictionary;
-import com.atilika.kuromoji.dict.UnknownDictionary;
-import com.atilika.kuromoji.dict.UserDictionary;
-import com.atilika.kuromoji.trie.DoubleArrayTrie;
 import com.atilika.kuromoji.viterbi.ViterbiNode;
 
-import java.io.BufferedInputStream;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Collections;
-
 public class Tokenizer extends AbstractTokenizer {
-
-    public static final String DEFAULT_DICT_PREFIX = "com/atilika/kuromoji/naist-jdic/";
-
-    public Tokenizer(Builder builder) {
-        super(
-            builder.doubleArrayTrie,
-            builder.connectionCosts,
-            builder.tokenInfoDictionary,
-            builder.unknownDictionary,
-            builder.userDictionary,
-            builder.insertedDictionary,
-            Mode.NORMAL,
-            true, // split,
-            Collections.EMPTY_LIST
-        );
-    }
 
     @Override
     protected Token createToken(int offset, ViterbiNode node, int wordId) {
@@ -65,75 +33,22 @@ public class Tokenizer extends AbstractTokenizer {
         );
     }
 
-    private static Tokenizer init(String[] args) throws IOException {
-        if (args.length == 1) {
-            return new Builder().userDictionary(args[0]).build();
+    public static class Builder extends AbstractTokenizer.Builder {
+
+        public Builder() {
+            totalFeatures = 11;
+            unknownDictionaryTotalFeatures = 11;
+            readingFeature = 7;
+            partOfSpeechFeature = 0;
+            defaultPrefix = System.getProperty(DEFAULT_DICT_PREFIX_PROPERTY, "com/atilika/kuromoji/naist-jdic/");
         }
 
-        return new Builder().build();
-    }
-
-    public static void main(String[] args) throws IOException {
-        Tokenizer tokenizer = init(args);
-        new TokenizerRunner().run(tokenizer);
-    }
-
-    public static class Builder {
-
-        private DoubleArrayTrie doubleArrayTrie;
-
-        private ConnectionCosts connectionCosts;
-
-        private TokenInfoDictionary tokenInfoDictionary;
-
-        private UnknownDictionary unknownDictionary;
-
-        private UserDictionary userDictionary = null;
-
-        private InsertedDictionary insertedDictionary;
-
-        private String defaultPrefix = System.getProperty(
-            DEFAULT_DICT_PREFIX_PROPERTY,
-            DEFAULT_DICT_PREFIX);
-
-        private ResourceResolver resolver = new ClassLoaderResolver(this.getClass());
-
-        public synchronized Builder userDictionary(InputStream userDictionaryInputStream) throws IOException {
-            this.userDictionary = new UserDictionary(
-                userDictionaryInputStream,
-                11, 7, 0
-            );
-            return this;
-        }
-
-        public synchronized Builder userDictionary(String userDictionaryPath) throws IOException {
-            if (userDictionaryPath != null && !userDictionaryPath.isEmpty()) {
-                this.userDictionary(new BufferedInputStream(new FileInputStream(userDictionaryPath)));
-            }
-            return this;
-        }
-
-        public synchronized Builder prefix(String resourcePrefix) {
-            this.defaultPrefix = resourcePrefix;
-            return this;
-        }
-
+        @Override
         public synchronized Tokenizer build() {
-            if (defaultPrefix != null) {
-                resolver = new PrefixDecoratorResolver(defaultPrefix, resolver);
-            }
-
-            try {
-                doubleArrayTrie = DoubleArrayTrie.newInstance(resolver);
-                connectionCosts = ConnectionCosts.newInstance(resolver);
-                tokenInfoDictionary = TokenInfoDictionary.newInstance(resolver);
-                unknownDictionary = UnknownDictionary.newInstance(resolver, 11);
-                insertedDictionary = new InsertedDictionary(11);
-            } catch (Exception ouch) {
-                throw new RuntimeException("Could not load dictionaries.", ouch);
-            }
-
-            return new Tokenizer(this);
+            Tokenizer tokenizer = new Tokenizer();
+            tokenizer.configure(this);
+            return tokenizer;
         }
+
     }
 }

--- a/kuromoji-unidic-kanaaccent/src/main/java/com/atilika/kuromoji/unidic/kanaaccent/Tokenizer.java
+++ b/kuromoji-unidic-kanaaccent/src/main/java/com/atilika/kuromoji/unidic/kanaaccent/Tokenizer.java
@@ -17,41 +17,9 @@
 package com.atilika.kuromoji.unidic.kanaaccent;
 
 import com.atilika.kuromoji.AbstractTokenizer;
-import com.atilika.kuromoji.ClassLoaderResolver;
-import com.atilika.kuromoji.PrefixDecoratorResolver;
-import com.atilika.kuromoji.ResourceResolver;
-import com.atilika.kuromoji.TokenizerRunner;
-import com.atilika.kuromoji.dict.ConnectionCosts;
-import com.atilika.kuromoji.dict.InsertedDictionary;
-import com.atilika.kuromoji.dict.TokenInfoDictionary;
-import com.atilika.kuromoji.dict.UnknownDictionary;
-import com.atilika.kuromoji.dict.UserDictionary;
-import com.atilika.kuromoji.trie.DoubleArrayTrie;
 import com.atilika.kuromoji.viterbi.ViterbiNode;
 
-import java.io.BufferedInputStream;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Collections;
-
 public class Tokenizer extends AbstractTokenizer {
-
-    public static final String DEFAULT_DICT_PREFIX = "com/atilika/kuromoji/unidic-kanaaccent/";
-
-    public Tokenizer(Builder builder) {
-        super(
-            builder.doubleArrayTrie,
-            builder.connectionCosts,
-            builder.tokenInfoDictionary,
-            builder.unknownDictionary,
-            builder.userDictionary,
-            builder.insertedDictionary,
-            Mode.NORMAL,
-            true, // split,
-            Collections.EMPTY_LIST
-        );
-    }
 
     @Override
     protected Token createToken(int offset, ViterbiNode node, int wordId) {
@@ -64,75 +32,22 @@ public class Tokenizer extends AbstractTokenizer {
         );
     }
 
-    private static Tokenizer init(String[] args) throws IOException {
-        if (args.length == 1) {
-            return new Builder().userDictionary(args[0]).build();
+
+    public static class Builder extends AbstractTokenizer.Builder {
+
+        public Builder() {
+            totalFeatures = 22;
+            unknownDictionaryTotalFeatures = 26;
+            readingFeature = 13;
+            partOfSpeechFeature = 0;
+            defaultPrefix = System.getProperty(DEFAULT_DICT_PREFIX_PROPERTY, "com/atilika/kuromoji/unidic-kanaaccent/");
         }
 
-        return new Builder().build();
-    }
-
-    public static void main(String[] args) throws IOException {
-        Tokenizer tokenizer = init(args);
-        new TokenizerRunner().run(tokenizer);
-    }
-
-    public static class Builder {
-
-        private DoubleArrayTrie doubleArrayTrie;
-
-        private ConnectionCosts connectionCosts;
-
-        private TokenInfoDictionary tokenInfoDictionary;
-
-        private UnknownDictionary unknownDictionary;
-
-        private UserDictionary userDictionary = null;
-
-        private InsertedDictionary insertedDictionary;
-
-        private String defaultPrefix = System.getProperty(
-            DEFAULT_DICT_PREFIX_PROPERTY,
-            DEFAULT_DICT_PREFIX);
-
-        private ResourceResolver resolver = new ClassLoaderResolver(this.getClass());
-
-        public synchronized Builder userDictionary(InputStream userDictionaryInputStream) throws IOException {
-            this.userDictionary = new UserDictionary(
-                userDictionaryInputStream,
-                22, 13, 0
-            );
-            return this;
-        }
-
-        public synchronized Builder userDictionary(String userDictionaryPath) throws IOException {
-            if (userDictionaryPath != null && !userDictionaryPath.isEmpty()) {
-                this.userDictionary(new BufferedInputStream(new FileInputStream(userDictionaryPath)));
-            }
-            return this;
-        }
-
-        public synchronized Builder prefix(String resourcePrefix) {
-            this.defaultPrefix = resourcePrefix;
-            return this;
-        }
-
+        @Override
         public synchronized Tokenizer build() {
-            if (defaultPrefix != null) {
-                resolver = new PrefixDecoratorResolver(defaultPrefix, resolver);
-            }
-
-            try {
-                doubleArrayTrie = DoubleArrayTrie.newInstance(resolver);
-                connectionCosts = ConnectionCosts.newInstance(resolver);
-                tokenInfoDictionary = TokenInfoDictionary.newInstance(resolver);
-                unknownDictionary = UnknownDictionary.newInstance(resolver, 26);
-                insertedDictionary = new InsertedDictionary(22);
-            } catch (Exception ouch) {
-                throw new RuntimeException("Could not load dictionaries.", ouch);
-            }
-
-            return new Tokenizer(this);
+            Tokenizer tokenizer = new Tokenizer();
+            tokenizer.configure(this);
+            return tokenizer;
         }
     }
 }

--- a/kuromoji-unidic-kanaaccent/src/main/java/com/atilika/kuromoji/unidic/kanaaccent/Tokenizer.java
+++ b/kuromoji-unidic-kanaaccent/src/main/java/com/atilika/kuromoji/unidic/kanaaccent/Tokenizer.java
@@ -21,6 +21,14 @@ import com.atilika.kuromoji.viterbi.ViterbiNode;
 
 public class Tokenizer extends AbstractTokenizer {
 
+    public Tokenizer() {
+        this(new Builder());
+    }
+
+    public Tokenizer(Builder builder) {
+        configure(builder);
+    }
+
     @Override
     protected Token createToken(int offset, ViterbiNode node, int wordId) {
         return new Token(
@@ -45,9 +53,7 @@ public class Tokenizer extends AbstractTokenizer {
 
         @Override
         public synchronized Tokenizer build() {
-            Tokenizer tokenizer = new Tokenizer();
-            tokenizer.configure(this);
-            return tokenizer;
+            return new Tokenizer(this);
         }
     }
 }

--- a/kuromoji-unidic/src/main/java/com/atilika/kuromoji/unidic/Tokenizer.java
+++ b/kuromoji-unidic/src/main/java/com/atilika/kuromoji/unidic/Tokenizer.java
@@ -18,41 +18,9 @@
 package com.atilika.kuromoji.unidic;
 
 import com.atilika.kuromoji.AbstractTokenizer;
-import com.atilika.kuromoji.ClassLoaderResolver;
-import com.atilika.kuromoji.PrefixDecoratorResolver;
-import com.atilika.kuromoji.ResourceResolver;
-import com.atilika.kuromoji.TokenizerRunner;
-import com.atilika.kuromoji.dict.ConnectionCosts;
-import com.atilika.kuromoji.dict.InsertedDictionary;
-import com.atilika.kuromoji.dict.TokenInfoDictionary;
-import com.atilika.kuromoji.dict.UnknownDictionary;
-import com.atilika.kuromoji.dict.UserDictionary;
-import com.atilika.kuromoji.trie.DoubleArrayTrie;
 import com.atilika.kuromoji.viterbi.ViterbiNode;
 
-import java.io.BufferedInputStream;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Collections;
-
 public class Tokenizer extends AbstractTokenizer {
-
-    public static final String DEFAULT_DICT_PREFIX = "com/atilika/kuromoji/unidic/";
-
-    public Tokenizer(Builder builder) {
-        super(
-            builder.doubleArrayTrie,
-            builder.connectionCosts,
-            builder.tokenInfoDictionary,
-            builder.unknownDictionary,
-            builder.userDictionary,
-            builder.insertedDictionary,
-            Mode.NORMAL,
-            true, // split,
-            Collections.EMPTY_LIST
-        );
-    }
 
     @Override
     protected Token createToken(int offset, ViterbiNode node, int wordId) {
@@ -65,75 +33,21 @@ public class Tokenizer extends AbstractTokenizer {
         );
     }
 
-    private static Tokenizer init(String[] args) throws IOException {
-        if (args.length == 1) {
-            return new Builder().userDictionary(args[0]).build();
+    public static class Builder extends AbstractTokenizer.Builder {
+
+        public Builder() {
+            totalFeatures = 13;
+            unknownDictionaryTotalFeatures = 17;
+            readingFeature = 7;
+            partOfSpeechFeature = 0;
+            defaultPrefix = System.getProperty(DEFAULT_DICT_PREFIX_PROPERTY, "com/atilika/kuromoji/unidic/");
         }
 
-        return new Builder().build();
-    }
-
-    public static void main(String[] args) throws IOException {
-        Tokenizer tokenizer = init(args);
-        new TokenizerRunner().run(tokenizer);
-    }
-
-    public static class Builder {
-
-        private DoubleArrayTrie doubleArrayTrie;
-
-        private ConnectionCosts connectionCosts;
-
-        private TokenInfoDictionary tokenInfoDictionary;
-
-        private UnknownDictionary unknownDictionary;
-
-        private UserDictionary userDictionary = null;
-
-        private InsertedDictionary insertedDictionary;
-
-        private String defaultPrefix = System.getProperty(
-            DEFAULT_DICT_PREFIX_PROPERTY,
-            DEFAULT_DICT_PREFIX);
-
-        private ResourceResolver resolver = new ClassLoaderResolver(this.getClass());
-
-        public synchronized Builder userDictionary(InputStream userDictionaryInputStream) throws IOException {
-            this.userDictionary = new UserDictionary(
-                userDictionaryInputStream,
-                13, 7, 0
-            );
-            return this;
-        }
-
-        public synchronized Builder userDictionary(String userDictionaryPath) throws IOException {
-            if (userDictionaryPath != null && !userDictionaryPath.isEmpty()) {
-                this.userDictionary(new BufferedInputStream(new FileInputStream(userDictionaryPath)));
-            }
-            return this;
-        }
-
-        public synchronized Builder prefix(String resourcePrefix) {
-            this.defaultPrefix = resourcePrefix;
-            return this;
-        }
-
+        @Override
         public synchronized Tokenizer build() {
-            if (defaultPrefix != null) {
-                resolver = new PrefixDecoratorResolver(defaultPrefix, resolver);
-            }
-
-            try {
-                doubleArrayTrie = DoubleArrayTrie.newInstance(resolver);
-                connectionCosts = ConnectionCosts.newInstance(resolver);
-                tokenInfoDictionary = TokenInfoDictionary.newInstance(resolver);
-                unknownDictionary = UnknownDictionary.newInstance(resolver, 17);
-                insertedDictionary = new InsertedDictionary(13);
-            } catch (Exception ouch) {
-                throw new RuntimeException("Could not load dictionaries.", ouch);
-            }
-
-            return new Tokenizer(this);
+            Tokenizer tokenizer = new Tokenizer();
+            tokenizer.configure(this);
+            return tokenizer;
         }
     }
 }

--- a/kuromoji-unidic/src/main/java/com/atilika/kuromoji/unidic/Tokenizer.java
+++ b/kuromoji-unidic/src/main/java/com/atilika/kuromoji/unidic/Tokenizer.java
@@ -22,6 +22,14 @@ import com.atilika.kuromoji.viterbi.ViterbiNode;
 
 public class Tokenizer extends AbstractTokenizer {
 
+    public Tokenizer() {
+        this(new Builder());
+    }
+
+    public Tokenizer(Builder builder) {
+        configure(builder);
+    }
+
     @Override
     protected Token createToken(int offset, ViterbiNode node, int wordId) {
         return new Token(
@@ -45,9 +53,7 @@ public class Tokenizer extends AbstractTokenizer {
 
         @Override
         public synchronized Tokenizer build() {
-            Tokenizer tokenizer = new Tokenizer();
-            tokenizer.configure(this);
-            return tokenizer;
+            return new Tokenizer(this);
         }
     }
 }


### PR DESCRIPTION
Changes to each implementation's Tokenizer to move common items to antecedents where appropriate.

Also added support for a default constructor, so that _new Tokenizer().tokenize("何々")_ works .