### PR TITLE
Added .travis.yml and updated .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,12 @@
 # Ignore IntelliJ IDEA files
 *.iml
 .idea/
+
+# Ignore Maven build directory
 target/
+
+# Ignore downloaded dictionary data
 dictionary/
+
+# Ignore compiled dictionaries
+*/src/main/resources/com/atilika/kuromoji/**/*.bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,5 @@ jdk:
   - oraclejdk7
 
 before_install:
-  - cat /home/travis/build.sh
   - sudo rm -f /etc/mavenrc
   - export MAVEN_OPTS=-Xmx3g
-
-install: mvn install -DskipTests=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: java
 jdk:
   - oraclejdk7
 
-before_install:
+before_script:
   - sudo rm -f /etc/mavenrc
   - export MAVEN_OPTS=-Xmx3g
+
+script:
+  - mvn install

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,11 @@ language: java
 jdk:
   - oraclejdk7
 
+before_script:
+ - "echo $JAVA_OPTS"
+ - "echo $MAVEN_OPTS"
+ - "export JAVA_OPTS=-Xmx2g"
+ - "export MAVEN_OPTS=-Xmx2g"
+
 install: mvn -q install -DskipTests=true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ before_install:
   - sudo rm -f /etc/mavenrc
 
 install:
-  - mvn install -DskipTests
+  - mvn install -DskipTests -pl kuromoji-ipadic -am
 
 script:
-  - mvn test -DskipCompileDictionary
+  - mvn test -DskipCompileDictionary -pl kuromoji-ipadic -am
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,8 @@ language: java
 jdk:
   - oraclejdk7
 
-before_script:
+before_install:
   - sudo rm -f /etc/mavenrc
-  - export MAVEN_OPTS=-Xmx2g
 
 script:
-  - mvn install
+  - mvn -X install

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,3 @@ jdk:
 
 before_install:
   - sudo rm -f /etc/mavenrc
-
-script:
-  - mvn -X install

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk:
 
 before_script:
   - sudo rm -f /etc/mavenrc
-  - export MAVEN_OPTS=-Xmx3g
+  - export MAVEN_OPTS=-Xmx2g
 
 script:
   - mvn install

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ before_script:
  - "echo $JAVA_OPTS"
  - "echo $MAVEN_OPTS"
 
-install: mvn -X install -DskipTests=true
+install: MAVEN_OPTS=-Xmx3g mvn -X install -DskipTests=true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ jdk:
 before_script:
  - "echo $JAVA_OPTS"
  - "echo $MAVEN_OPTS"
- - "export JAVA_OPTS=-Xmx2g"
- - "export MAVEN_OPTS=-Xmx2g"
 
-install: mvn -q install -DskipTests=true
+install: mvn install -DskipTests=true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ jdk:
   - oraclejdk7
 
 before_install:
-  - sudo rm /etc/mavenrc
+  - cat /home/travis/build.sh
+  - sudo rm -f /etc/mavenrc
   - export MAVEN_OPTS=-Xmx3g
 
 install: mvn install -DskipTests=true
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: java
 jdk:
   - oraclejdk7
 
-before_script:
- - "echo $JAVA_OPTS"
- - "echo $MAVEN_OPTS"
+before_install:
+  - sudo rm /etc/mavenrc
+  - export MAVEN_OPTS=-Xmx3g
 
-install: MAVEN_OPTS=-Xmx3g mvn -X install -DskipTests=true
+install: mvn install -DskipTests=true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ before_install:
   - sudo rm -f /etc/mavenrc
 
 install:
-  - mvn install -DskipTests -pl kuromoji-ipadic -am
+  - mvn install -DskipTests -pl kuromoji-ipadic -pl kuromoji-unidic -am
 
 script:
-  - mvn test -DskipCompileDictionary -pl kuromoji-ipadic -am
+  - mvn test -DskipCompileDictionary -pl kuromoji-ipadic -pl kuromoji-unidic -am
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ before_script:
  - "echo $JAVA_OPTS"
  - "echo $MAVEN_OPTS"
 
-install: mvn install -DskipTests=true
+install: mvn -X install -DskipTests=true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,10 @@ jdk:
 
 before_install:
   - sudo rm -f /etc/mavenrc
+
+install:
+  - mvn install -DskipTests
+
+script:
+  - mvn test -DskipCompileDictionary
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: java
+jdk:
+  - oraclejdk7
+
+install: mvn -q install -DskipTests=true
+


### PR DESCRIPTION
Added sample .travis.yml that builds kuromoji-common, kuromoji-ipadic and kuromoji-unidic. Building all the dictionaries doesn't seem stable with the open source travis offering so we're currently only building these two dictionaries.

Minor updates to .gitignore.