### PR TITLE
Improve FST and token-feature compactness

### DIFF
--- a/kuromoji-core/src/main/java/com/atilika/kuromoji/buffer/StringValueMapBuffer.java
+++ b/kuromoji-core/src/main/java/com/atilika/kuromoji/buffer/StringValueMapBuffer.java
@@ -63,13 +63,13 @@ public class StringValueMapBuffer {
     private int calculateSize(TreeMap<Integer, String> input) {
         int size = 0;
         for (String value : input.values()) {
-            size += INTEGER_BYTES + value.getBytes(StandardCharsets.UTF_8).length + 2 * INTEGER_BYTES;
+            size += INTEGER_BYTES + value.getBytes(StandardCharsets.UTF_16).length + 2 * INTEGER_BYTES;
         }
         return size;
     }
 
     private int putString(int address, String s) {
-        byte[] bytes = s.getBytes(StandardCharsets.UTF_8);
+        byte[] bytes = s.getBytes(StandardCharsets.UTF_16);
 
         buffer.position(address);
         // TODO: The length field in the entry (bytes.length) field can be optimized (shrunk) for most dictionary types.
@@ -86,7 +86,7 @@ public class StringValueMapBuffer {
 
     private String getString(int address) {
         int length = buffer.getShort(address);
-        return new String(buffer.array(), address + SHORT_BYTES, length, StandardCharsets.UTF_8);
+        return new String(buffer.array(), address + SHORT_BYTES, length, StandardCharsets.UTF_16);
     }
 
     public void write(OutputStream os) throws IOException {

--- a/kuromoji-core/src/main/java/com/atilika/kuromoji/compile/FSTCompiler.java
+++ b/kuromoji-core/src/main/java/com/atilika/kuromoji/compile/FSTCompiler.java
@@ -44,7 +44,7 @@ public class FSTCompiler implements Compiler {
         builder.build(surfaces, null) ;
 
         ByteBuffer fst = ByteBuffer.wrap(
-            builder.getCompiler().getByteArray()
+            builder.getCompiler().getBytes()
         );
 
         ByteBufferIO.write(output, fst);

--- a/kuromoji-core/src/main/java/com/atilika/kuromoji/fst/Arc.java
+++ b/kuromoji-core/src/main/java/com/atilika/kuromoji/fst/Arc.java
@@ -17,9 +17,12 @@
 package com.atilika.kuromoji.fst;
 
 public class Arc {
-    char label;
-    int output = 0;
-    State destination;
+
+    private char label;
+
+    private int output = 0;
+
+    private State destination;
 
     public Arc(int output, State destination, char label) {
         this.output = output;
@@ -43,7 +46,9 @@ public class Arc {
         return this.label;
     }
 
-    public void setOutput(Integer output) {this.output = output;}
+    public void setOutput(int output) {
+        this.output = output;
+    }
 
     public void setLabel(char label) {
         this.label = label;

--- a/kuromoji-core/src/main/java/com/atilika/kuromoji/fst/Bits.java
+++ b/kuromoji-core/src/main/java/com/atilika/kuromoji/fst/Bits.java
@@ -29,4 +29,53 @@ public class Bits {
     public static int getInt(byte[] bytes, int index) {
         return (bytes[index - 3] & 0xff) << 24 | (bytes[index - 2] & 0xff) << 16 | (bytes[index - 1] & 0xff) << 8 | (bytes[index] & 0xff);
     }
+
+    public static int getInt(byte[] bytes, int index, int intBytes) {
+        switch (intBytes) {
+            case 0:
+                return 0;
+
+            case 1:
+                return bytes[index] & 0xff;
+
+            case 2:
+                return (bytes[index - 1] & 0xff) << 8 | (bytes[index] & 0xff);
+
+            case 3:
+                return (bytes[index - 2] & 0xff) << 16 | (bytes[index - 1] & 0xff) << 8 | (bytes[index] & 0xff);
+
+            case 4:
+                return (bytes[index - 3] & 0xff) << 24 | (bytes[index - 2] & 0xff) << 16 | (bytes[index - 1] & 0xff) << 8 | (bytes[index] & 0xff);
+
+            default:
+                throw new RuntimeException("Illegal int byte size: " + intBytes);
+        }
+    }
+
+    public static void putInt(byte[] bytes, int index, int value, int intBytes) {
+        switch (intBytes) {
+            case 1:
+                bytes[index] = (byte) (value & 0xff);
+                break;
+
+            case 2:
+                bytes[index - 1] = (byte) (value >> 8 & 0xff);
+                bytes[index] = (byte) (value & 0xff);
+                break;
+
+            case 3:
+                bytes[index - 2] = (byte) (value >> 16 & 0xff);
+                bytes[index - 1] = (byte) (value >> 8 & 0xff);
+                bytes[index] = (byte) (value & 0xff);
+
+            case 4:
+                bytes[index - 3] = (byte) (value >> 24 & 0xff);
+                bytes[index - 2] = (byte) (value >> 16 & 0xff);
+                bytes[index - 1] = (byte) (value >> 8 & 0xff);
+                bytes[index] = (byte) (value & 0xff);
+
+            default:
+                throw new RuntimeException("Illegal int byte size: " + intBytes);
+        }
+    }
 }

--- a/kuromoji-core/src/main/java/com/atilika/kuromoji/fst/BitsFormatter.java
+++ b/kuromoji-core/src/main/java/com/atilika/kuromoji/fst/BitsFormatter.java
@@ -50,31 +50,38 @@ public class BitsFormatter {
     }
 
     public int stateSize(byte[] fst, int address) {
-        return 1 + 2 + Bits.getShort(fst, address - 1) * Compiler.ARC_SIZE;
+        byte stateTypByte = Bits.getByte(fst, address);
+        int jumpBytes = (stateTypByte & 0x03) + 1;
+        int accumulateBytes = (stateTypByte & 0x03 << 3) >> 3;
+
+        return 1 + 2 + Bits.getShort(fst, address - 1) * (2 + accumulateBytes + jumpBytes);
     }
 
     public String formatState(byte[] fst, int address) {
         StringBuilder builder = new StringBuilder();
 
-        builder.append(formatStateType(fst, address));
-        builder.append(formatArcs(fst, address - 1));
+        byte stateByte = Bits.getByte(fst, address);
+        byte stateType = (byte) (stateByte & 0x80);
+        int jumpBytes = (stateByte & 0x03) + 1;
+        int accumulateBytes = (stateByte & 0x03 << 3) >> 3;
+
+        builder.append(formatStateType(stateType, address));
+        builder.append(formatArcs(fst, address - 1, accumulateBytes, jumpBytes));
 
         return builder.toString();
     }
 
-    public String formatStateType(byte[] fst, int address) {
+    public String formatStateType(byte stateByte, int address) {
         StringBuilder builder = new StringBuilder();
         builder.append(formatAddress(address));
         builder.append(" ");
 
-        byte type = Bits.getByte(fst, address);
-
-        if (type == Compiler.STATE_TYPE_ACCEPT) {
+        if (stateByte == Compiler.STATE_TYPE_ACCEPT) {
             builder.append("ACCEPT");
-        } else if (type == Compiler.STATE_TYPE_MATCH) {
+        } else if (stateByte == Compiler.STATE_TYPE_MATCH) {
             builder.append("MATCH");
         } else {
-            throw new IllegalStateException("Illegal state type: " + type);
+            throw new IllegalStateException("Illegal state type: " + stateByte);
         }
 
         builder.append("\n");
@@ -85,7 +92,7 @@ public class BitsFormatter {
         return String.format("%4d:", address);
     }
 
-    public String formatArcs(byte[] fst, int address) {
+    public String formatArcs(byte[] fst, int address, int accumulateBytes, int jumpBytes) {
         StringBuilder builder = new StringBuilder();
         int arcs = Bits.getShort(fst, address);
 
@@ -93,23 +100,24 @@ public class BitsFormatter {
 
         for (int i = 0; i < arcs; i++) {
             builder.append(formatAddress(address));
-            builder.append(formatArc(fst, address));
+            builder.append(formatArc(fst, address, accumulateBytes, jumpBytes));
             builder.append("\n");
-            address -= Compiler.ARC_SIZE;
+            address -= 2 + accumulateBytes + jumpBytes;
         }
 
         return builder.toString();
     }
 
-    public String formatArc(byte[] fst, int address) {
+    public String formatArc(byte[] fst, int address, int accumulateBytes, int jumpBytes) {
         StringBuilder builder = new StringBuilder();
-        int output = Bits.getInt(fst, address);
-        address -= 4;
+        int output = Bits.getInt(fst, address, accumulateBytes);
+        address -= accumulateBytes;
 
-        int jumpAddress = Bits.getInt(fst, address);
-        address -= 4;
+        int jumpAddress = Bits.getInt(fst, address, jumpBytes);
+        address -= jumpBytes;
 
         char label = (char) Bits.getShort(fst, address);
+//        address -= 1;
 
         builder.append('\t');
         builder.append(label);

--- a/kuromoji-core/src/main/java/com/atilika/kuromoji/fst/Compiler.java
+++ b/kuromoji-core/src/main/java/com/atilika/kuromoji/fst/Compiler.java
@@ -25,21 +25,21 @@ import java.util.List;
 public class Compiler {
 
     /**
-     * 1 byte   node type: 0x01 = accept, 0x02 = match
+     * 1 byte   bit 7: true => accept, false => match
+     *          bits 3-6 indicate number of bytes in output value (m)
+     *          bits 0-2 indicate number of bytes in jump address (n)
      * 2 bytes  number of outgoing arcs
      * [
      *  (
      *   2 bytes label (char),
-     *   4 bytes jump address,
-     *   4 bytes accumlator
+     *   n bytes jump address,
+     *   m bytes accumlator
      *  )
      * ]
      */
-    public static final byte STATE_TYPE_MATCH = 0x01;
+    public static final byte STATE_TYPE_MATCH = (byte) 0x00;
 
-    public static final byte STATE_TYPE_ACCEPT = 0x02;
-
-    public static final int ARC_SIZE = 2 + 4 + 4;
+    public static final byte STATE_TYPE_ACCEPT = (byte) 0x80;
 
     private ByteArrayOutputStream byteArrayOutput;
 
@@ -53,46 +53,137 @@ public class Compiler {
     }
 
     public void compileState(State state) throws IOException {
-        writeStateArcs(state);
-        writeStateType(state);
-
         if (state.getTargetJumpAddress() == -1) {
+            int jumpBytes = findMaxJumpAddressBytes(state);
+            int outputBytes = findMaxOutputBytes(state);
+
+            writeStateArcs(state, outputBytes, jumpBytes);
+            writeStateType(state, outputBytes, jumpBytes);
             // The last arc is regarded as a state because we evaluate the FST backwards.
             state.setTargetJumpAddress(written - 1);
         }
     }
 
-    private void writeStateType(State state) throws IOException {
+    private void writeStateType(State state, int outputBytes, int jumpBytes) throws IOException {
+        byte stateType;
+
         if (state.isFinal()) {
-            dataOutput.writeByte(STATE_TYPE_ACCEPT);
+            stateType = STATE_TYPE_ACCEPT;
         } else {
-            dataOutput.writeByte(STATE_TYPE_MATCH);
+            stateType = STATE_TYPE_MATCH;
         }
+
+        stateType |= jumpBytes - 1;
+        stateType |= outputBytes << 3;
+
+        dataOutput.writeByte(stateType);
+
         written += 1;
     }
 
-    private void writeStateArcs(State state) throws IOException {
+    private void writeStateArcs(State state, int outputBytes, int jumpBytes) throws IOException {
         List<Arc> arcs = state.arcs;
 
         for (Arc arc : arcs) {
-            writeStateArc(arc);
+            writeStateArc(arc, outputBytes, jumpBytes);
         }
 
         dataOutput.writeShort(arcs.size());
         written += 2;
     }
 
-    private void writeStateArc(Arc arc) throws IOException {
+    private void writeStateArc(Arc arc, int outputBytes, int jumpBytes) throws IOException {
         State target = arc.getDestination();
+        int arcSize = 2 + jumpBytes + outputBytes; // label + bytes for a jump + output
 
         dataOutput.writeShort(arc.getLabel());
-        dataOutput.writeInt(target.getTargetJumpAddress());
-        dataOutput.writeInt(arc.getOutput());
+        writeIntValue(target.getTargetJumpAddress(), jumpBytes);
+        writeIntValue(arc.getOutput(), outputBytes);
 
-        written += ARC_SIZE;
+        written += arcSize;
     }
 
-    public byte[] getByteArray() {
+    private void writeIntValue(int value, int bytes) throws IOException {
+        switch (bytes) {
+            case 0:
+                break;
+
+            case 1:
+                dataOutput.writeByte(value & 0xff);
+                break;
+
+            case 2:
+                dataOutput.writeByte((value >> 8) & 0xff);
+                dataOutput.writeByte(value & 0xff);
+                break;
+
+            case 3:
+                dataOutput.writeByte((value >> 16) & 0xff);
+                dataOutput.writeByte((value >> 8) & 0xff);
+                dataOutput.writeByte(value & 0xff);
+                break;
+
+            case 4:
+                dataOutput.writeByte((value >> 24) & 0xff);
+                dataOutput.writeByte((value >> 16) & 0xff);
+                dataOutput.writeByte((value >> 8) & 0xff);
+                dataOutput.writeByte(value & 0xff);
+                break;
+
+            default:
+                throw new RuntimeException("Illegal int byte size: " + bytes);
+        }
+    }
+
+    private int findMaxJumpAddressBytes(State state) {
+        int maxJumpAddress = 0;
+
+        for (Arc arc : state.arcs) {
+            int jumpAddress = arc.getDestination().getTargetJumpAddress();
+
+            if (maxJumpAddress < jumpAddress) {
+                maxJumpAddress = jumpAddress;
+            }
+        }
+
+        return findBytes(maxJumpAddress);
+    }
+
+    private int findMaxOutputBytes(State state) {
+        int maxOutput = 0;
+
+        for (Arc arc : state.arcs) {
+            int output = arc.getOutput();
+
+            if (maxOutput < output) {
+                maxOutput = output;
+            }
+        }
+
+        if (maxOutput == 0) {
+            return 0;
+        }
+
+        return findBytes(maxOutput);
+    }
+
+    private int findBytes(int value) {
+        if (value < 256) {
+            return 1;
+        }
+
+        if (value < 65536) {
+            return 2;
+        }
+
+        if (value < 16777216) {
+            return 3;
+        }
+
+        return 4;
+    }
+
+    public byte[] getBytes() {
         return byteArrayOutput.toByteArray();
     }
 }

--- a/kuromoji-core/src/main/java/com/atilika/kuromoji/fst/FST.java
+++ b/kuromoji-core/src/main/java/com/atilika/kuromoji/fst/FST.java
@@ -31,36 +31,44 @@ public class FST {
 
     private int[] jumpCache = new int[65536];
 
-    public FST(byte[] compiled) throws IOException {
+    private int[] outputCache = new int[65536];
+
+    public FST(byte[] compiled) {
         this.fst = compiled;
         initCache();
     }
 
     public FST(InputStream input) throws IOException {
-        this.fst = ByteBufferIO.read(input).array();
-        initCache();
+        this(ByteBufferIO.read(input).array());
     }
 
     private void initCache() {
         Arrays.fill(jumpCache, -1);
+        Arrays.fill(outputCache, -1);
 
-        int address = fst.length - 1 - 1;
+        int address = fst.length - 1;
+
+        final byte stateType = Bits.getByte(fst, address);
+        address -= 1;
+
+        final int jumpBytes = (stateType & 0x03) + 1;
+        final int outputBytes = (stateType & 0x03 << 3) >> 3;
 
         int arcs = Bits.getShort(fst, address);
         address -= 2;
 
         for (int i = 0; i < arcs; i++) {
+            final int output = Bits.getInt(fst, address, outputBytes);
+            address -= outputBytes;
 
-            final int output = Bits.getInt(fst, address);
-            address -= 4;
-
-            final int jump = Bits.getInt(fst, address);
-            address -= 4;
+            final int jump = Bits.getInt(fst, address, jumpBytes);
+            address -= jumpBytes;
 
             final char label = (char) Bits.getShort(fst, address);
             address -= 2;
 
-            jumpCache[label] = address + Compiler.ARC_SIZE;
+            jumpCache[label] = jump;
+            outputCache[label] = output;
         }
     }
 
@@ -71,7 +79,17 @@ public class FST {
         int index = 0;
 
         while (true) {
-            final byte stateType = Bits.getByte(fst, address);
+            final byte stateTypByte = Bits.getByte(fst, address);
+
+            // The number of bytes in the target address (always larger than zero)
+            final int jumpBytes = (stateTypByte & 0x03) + 1;
+
+            // The number of bytes in the output value
+            int outputBytes = (stateTypByte & 0x03 << 3) >> 3;
+
+            final int arcSize = 2 + jumpBytes + outputBytes;
+
+            final byte stateType = (byte) (stateTypByte & 0x80);
             address -= 1;
 
             if (index == length) {
@@ -88,20 +106,16 @@ public class FST {
                 //
                 // Processes cached root arcs - transition directly to the next state on a match
                 //
-                int jump = jumpCache[c];
+                final int jump = jumpCache[c];
 
                 if (jump == -1) {
                     return -1;
                 }
 
-                address = jump;
-
-                final int output = Bits.getInt(fst, address);
-                address -= 4;
-
+                final int output = outputCache[c];
                 accumulator += output;
 
-                address = Bits.getInt(fst, address);
+                address = jump;
                 matched = true;
             } else {
                 //
@@ -119,13 +133,14 @@ public class FST {
 
                 while (low <= high) {
                     final int middle = low + (high - low) / 2;
-                    final int arcAddr = address - middle * Compiler.ARC_SIZE;
-                    final char label = (char) Bits.getShort(fst, arcAddr - 8);
+                    final int arcAddr = address - middle * arcSize;
+
+                    final char label = getArcLabel(arcAddr, outputBytes, jumpBytes);
 
                     if (label == c) {
                         matched = true;
-                        address = Bits.getInt(fst, arcAddr - 4);
-                        accumulator += Bits.getInt(fst, arcAddr);
+                        address = getArcJump(arcAddr, outputBytes, jumpBytes);
+                        accumulator += getArcOutput(arcAddr, outputBytes, jumpBytes);
                         break;
                     } else if (label > c) {
                         low = middle + 1;
@@ -141,6 +156,18 @@ public class FST {
 
             index++;
         }
+    }
+
+    private char getArcLabel(final int arcAddress, final int accumulateBytes, final int jumpBytes) {
+        return (char) Bits.getShort(fst, arcAddress - (accumulateBytes + jumpBytes));
+    }
+
+    private int getArcJump(final int arcAddress, final int accumulateBytes, final int jumpBytes) {
+        return Bits.getInt(fst, arcAddress - accumulateBytes, jumpBytes);
+    }
+
+    private int getArcOutput(final int arcAddress, final int accumulateBytes, final int jumpBytes) {
+        return Bits.getInt(fst, arcAddress, accumulateBytes);
     }
 
     public static FST newInstance(ResourceResolver resolver) throws IOException {

--- a/kuromoji-core/src/test/java/com/atilika/kuromoji/fst/BitsFormatterTest.java
+++ b/kuromoji-core/src/test/java/com/atilika/kuromoji/fst/BitsFormatterTest.java
@@ -37,24 +37,23 @@ public class BitsFormatterTest {
         Compiler compiledFST = builder.getCompiler();
 
         assertEquals("" +
-            " 106: MATCH\n" +
-            " 103:\tr -> 30\t(JMP: 83)\n" +
-            "  93:\tc -> 10\t(JMP: 41)\n" +
-            "  83: MATCH\n" +
-            "  80:\ta -> 0\t(JMP: 70)\n" +
-            "  70: MATCH\n" +
-            "  67:\tt -> 0\t(JMP: 57)\n" +
-            "  57: MATCH\n" +
-            "  54:\ts -> 0\t(JMP: 2)\n" +
-            "  44: ACCEPT\n" +
-            "  41: MATCH\n" +
-            "  38:\ta -> 0\t(JMP: 28)\n" +
-            "  28: MATCH\n" +
-            "  25:\tt -> 0\t(JMP: 15)\n" +
-            "  15: ACCEPT\n" +
-            "  12:\ts -> 10\t(JMP: 2)\n" +
+            "  50: MATCH\n" +
+            "  47:\tr -> 30\t(JMP: 39)\n" +
+            "  43:\tc -> 10\t(JMP: 21)\n" +
+            "  39: MATCH\n" +
+            "  36:\ta -> 0\t(JMP: 33)\n" +
+            "  33: MATCH\n" +
+            "  30:\tt -> 0\t(JMP: 27)\n" +
+            "  27: MATCH\n" +
+            "  24:\ts -> 0\t(JMP: 2)\n" +
+            "  21: MATCH\n" +
+            "  18:\ta -> 0\t(JMP: 15)\n" +
+            "  15: MATCH\n" +
+            "  12:\tt -> 0\t(JMP: 9)\n" +
+            "   9: ACCEPT\n" +
+            "   6:\ts -> 10\t(JMP: 2)\n" +
             "   2: ACCEPT\n",
-            formatter.format(compiledFST.getByteArray())
+            formatter.format(compiledFST.getBytes())
         );
     }
 }

--- a/kuromoji-core/src/test/java/com/atilika/kuromoji/fst/FSTTest.java
+++ b/kuromoji-core/src/test/java/com/atilika/kuromoji/fst/FSTTest.java
@@ -25,7 +25,7 @@ import static org.junit.Assert.assertEquals;
 public class FSTTest {
 
     @Test
-    public void testFST2() throws IOException {
+    public void testFST() throws IOException {
         String inputValues[] = {
             "brats", "cat", "dog", "dogs", "rat",
         };

--- a/kuromoji-core/src/test/java/com/atilika/kuromoji/fst/FSTTest.java
+++ b/kuromoji-core/src/test/java/com/atilika/kuromoji/fst/FSTTest.java
@@ -42,7 +42,7 @@ public class FSTTest {
         }
 
         Compiler compiledFST = builder.getCompiler();
-        FST fst = new FST(compiledFST.getByteArray());
+        FST fst = new FST(compiledFST.getBytes());
 
         assertEquals(0, fst.lookup("brat")); // Prefix match
         assertEquals(1, fst.lookup("brats"));


### PR DESCRIPTION
This pull-requests improve FST compactness by only using the required number of bytes to encode target states and output values in the compiled FST. In case outputs for all arcs are zero, which is quite common, no output storage is used for these arcs.

Token-feature compactness and also speed has been improved by using UTF-16 encoding instead of UTF-8, which is a more efficient encoding overall for our data.

The above changes gives quite significant improvements in memory usage for the IPADIC NEologd and UniDic NEologd dictionaries. 