### PR TITLE
Update to NIO read methods to support Android implementation

### DIFF
--- a/kuromoji-core/src/main/java/com/atilika/kuromoji/buffer/StringValueMapBuffer.java
+++ b/kuromoji-core/src/main/java/com/atilika/kuromoji/buffer/StringValueMapBuffer.java
@@ -19,6 +19,7 @@ package com.atilika.kuromoji.buffer;
 import com.atilika.kuromoji.io.ByteBufferIO;
 import com.atilika.kuromoji.util.ScriptUtils;
 
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -47,7 +48,7 @@ public class StringValueMapBuffer {
     }
 
     public StringValueMapBuffer(InputStream is) throws IOException {
-        buffer = ByteBufferIO.read(is);
+        buffer = ByteBufferIO.read(new BufferedInputStream(is));
         size = buffer.getInt();
     }
 

--- a/kuromoji-core/src/main/java/com/atilika/kuromoji/buffer/TokenInfoBuffer.java
+++ b/kuromoji-core/src/main/java/com/atilika/kuromoji/buffer/TokenInfoBuffer.java
@@ -18,6 +18,7 @@ package com.atilika.kuromoji.buffer;
 
 import com.atilika.kuromoji.io.ByteBufferIO;
 
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
@@ -36,7 +37,7 @@ public class TokenInfoBuffer {
     private final int entrySize;
 
     public TokenInfoBuffer(InputStream is) throws IOException {
-        buffer = ByteBufferIO.read(is);
+        buffer = ByteBufferIO.read(new BufferedInputStream(is));
         tokenInfoCount = getTokenInfoCount();
         posInfoCount = getPosInfoCount();
         featureCount = getFeatureCount();

--- a/kuromoji-core/src/main/java/com/atilika/kuromoji/buffer/WordIdMap.java
+++ b/kuromoji-core/src/main/java/com/atilika/kuromoji/buffer/WordIdMap.java
@@ -31,8 +31,9 @@ public class WordIdMap {
     private final int[] empty = new int[]{};
 
     public WordIdMap(InputStream input) throws IOException {
-        indices = IntegerArrayIO.readArray(input);
-        wordIds = IntegerArrayIO.readArray(input);
+        int arrays[][] = IntegerArrayIO.readArrays(input, 2);
+        indices = arrays[0];
+        wordIds = arrays[1];
     }
 
     public int[] lookUp(int sourceId) {

--- a/kuromoji-core/src/main/java/com/atilika/kuromoji/dict/TokenInfoDictionary.java
+++ b/kuromoji-core/src/main/java/com/atilika/kuromoji/dict/TokenInfoDictionary.java
@@ -17,12 +17,12 @@
 package com.atilika.kuromoji.dict;
 
 import com.atilika.kuromoji.buffer.BufferEntry;
-import com.atilika.kuromoji.util.ResourceResolver;
-import com.atilika.kuromoji.util.DictionaryEntryLineParser;
-import com.atilika.kuromoji.util.StringUtils;
 import com.atilika.kuromoji.buffer.StringValueMapBuffer;
 import com.atilika.kuromoji.buffer.TokenInfoBuffer;
 import com.atilika.kuromoji.buffer.WordIdMap;
+import com.atilika.kuromoji.util.DictionaryEntryLineParser;
+import com.atilika.kuromoji.util.ResourceResolver;
+import com.atilika.kuromoji.util.StringUtils;
 
 import java.io.IOException;
 

--- a/kuromoji-core/src/main/java/com/atilika/kuromoji/io/ByteBufferIO.java
+++ b/kuromoji-core/src/main/java/com/atilika/kuromoji/io/ByteBufferIO.java
@@ -6,7 +6,7 @@
  * License is distributed with this work in the LICENSE.md file.  You may
  * also obtain a copy of the License from
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +16,6 @@
  */
 package com.atilika.kuromoji.io;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -31,24 +29,22 @@ import java.nio.channels.WritableByteChannel;
 public class ByteBufferIO {
 
     public static ByteBuffer read(InputStream input) throws IOException {
-        DataInputStream dataInput = new DataInputStream(
-            new BufferedInputStream(input)
-        );
+        DataInputStream dataInput = new DataInputStream(input);
 
         int size = dataInput.readInt();
         ByteBuffer buffer = ByteBuffer.allocate(size);
 
         ReadableByteChannel channel = Channels.newChannel(dataInput);
-        channel.read(buffer);
+        while (buffer.hasRemaining()) {
+            channel.read(buffer);
+        }
 
         buffer.rewind();
         return buffer;
     }
 
     public static void write(OutputStream output, ByteBuffer buffer) throws IOException {
-        DataOutputStream dataOutput = new DataOutputStream(
-            new BufferedOutputStream(output)
-        );
+        DataOutputStream dataOutput = new DataOutputStream(output);
 
         buffer = buffer.duplicate();
         buffer.rewind();

--- a/kuromoji-core/src/main/java/com/atilika/kuromoji/io/ByteBufferIO.java
+++ b/kuromoji-core/src/main/java/com/atilika/kuromoji/io/ByteBufferIO.java
@@ -6,7 +6,7 @@
  * License is distributed with this work in the LICENSE.md file.  You may
  * also obtain a copy of the License from
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/kuromoji-core/src/main/java/com/atilika/kuromoji/io/IntegerArrayIO.java
+++ b/kuromoji-core/src/main/java/com/atilika/kuromoji/io/IntegerArrayIO.java
@@ -6,7 +6,7 @@
  * License is distributed with this work in the LICENSE.md file.  You may
  * also obtain a copy of the License from
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/kuromoji-core/src/main/java/com/atilika/kuromoji/io/IntegerArrayIO.java
+++ b/kuromoji-core/src/main/java/com/atilika/kuromoji/io/IntegerArrayIO.java
@@ -6,7 +6,7 @@
  * License is distributed with this work in the LICENSE.md file.  You may
  * also obtain a copy of the License from
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -105,30 +105,23 @@ public class IntegerArrayIO {
         dataOutput.writeInt(-1);
     }
 
-    private static int readIntFromByteChannel(ReadableByteChannel channel) {
+    private static int readIntFromByteChannel(ReadableByteChannel channel) throws IOException {
         ByteBuffer intBuffer = ByteBuffer.allocate(INT_BYTES);
         int result = -1;
-        try {
-            while (intBuffer.hasRemaining() && (channel.read(intBuffer) >= 0)) {
-            }
-            if (!intBuffer.hasRemaining()) {
-                intBuffer.rewind();
-                result = intBuffer.asIntBuffer().get(0);
-            }
-        } catch (Exception ignored) {
+        while (intBuffer.hasRemaining() && (channel.read(intBuffer) >= 0)) {
+        }
+        if (!intBuffer.hasRemaining()) {
+            intBuffer.rewind();
+            result = intBuffer.asIntBuffer().get(0);
         }
         return result;
     }
 
-    private static int[] readArrayFromChannel(ReadableByteChannel channel) {
+    private static int[] readArrayFromChannel(ReadableByteChannel channel) throws IOException {
         int length = readIntFromByteChannel(channel);
 
         ByteBuffer tmpBuffer = ByteBuffer.allocate(length * INT_BYTES);
-        try {
-            while (tmpBuffer.hasRemaining() && (channel.read(tmpBuffer) >= 0)) {
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
+        while (tmpBuffer.hasRemaining() && (channel.read(tmpBuffer) >= 0)) {
         }
         tmpBuffer.rewind();
         IntBuffer intBuffer = tmpBuffer.asIntBuffer();

--- a/kuromoji-core/src/main/java/com/atilika/kuromoji/io/IntegerArrayIO.java
+++ b/kuromoji-core/src/main/java/com/atilika/kuromoji/io/IntegerArrayIO.java
@@ -31,21 +31,13 @@ public class IntegerArrayIO {
 
     private static final int INT_BYTES = Integer.SIZE / Byte.SIZE;
 
-    public static int[] readArray(InputStream input) throws IOException {
-        DataInputStream dataInput = new DataInputStream(input);
-        int length = dataInput.readInt();
-
-        ByteBuffer tmpBuffer = ByteBuffer.allocate(length * INT_BYTES);
-        ReadableByteChannel channel = Channels.newChannel(dataInput);
-        channel.read(tmpBuffer);
-
-        tmpBuffer.rewind();
-        IntBuffer intBuffer = tmpBuffer.asIntBuffer();
-
-        int[] array = new int[length];
-        intBuffer.get(array);
-
-        return array;
+    public static int[][] readArrays(InputStream input, int arrayCount) throws IOException {
+        int[][] arrays = new int[arrayCount][];
+        ReadableByteChannel channel = Channels.newChannel(input);
+        for (int i = 0; i < arrayCount; i++) {
+            arrays[i] = readArrayFromChannel(channel);
+        }
+        return arrays;
     }
 
     public static void writeArray(OutputStream output, int[] array) throws IOException {
@@ -66,15 +58,8 @@ public class IntegerArrayIO {
 
     public static int[][] readArray2D(InputStream input) throws IOException {
         DataInputStream dataInput = new DataInputStream(input);
-        int length = dataInput.readInt();
 
-        int[][] array = new int[length][];
-
-        for (int i = 0; i < length; i++) {
-            array[i] = readArray(dataInput);
-        }
-
-        return array;
+        return readArrays(dataInput, dataInput.readInt());
     }
 
     public static void writeArray2D(OutputStream output, int[][] array) throws IOException {
@@ -89,18 +74,17 @@ public class IntegerArrayIO {
     }
 
     public static int[][] readSparseArray2D(InputStream input) throws IOException {
-        DataInputStream dataInput = new DataInputStream(input);
-        int length = dataInput.readInt();
+        ReadableByteChannel channel = Channels.newChannel(input);
 
-        int[][] array = new int[length][];
+        int arrayCount = readIntFromByteChannel(channel);
+        int[][] arrays = new int[arrayCount][];
 
         int index;
 
-        while ((index = dataInput.readInt()) >= 0) {
-            array[index] = readArray(dataInput);
+        while ((index = readIntFromByteChannel(channel)) >= 0) {
+            arrays[index] = readArrayFromChannel(channel);
         }
-
-        return array;
+        return arrays;
     }
 
     public static void writeSparseArray2D(OutputStream output, int[][] array) throws IOException {
@@ -119,5 +103,38 @@ public class IntegerArrayIO {
         }
         // This negative index serves as an end-of-array marker
         dataOutput.writeInt(-1);
+    }
+
+    private static int readIntFromByteChannel(ReadableByteChannel channel) {
+        ByteBuffer intBuffer = ByteBuffer.allocate(INT_BYTES);
+        int result = -1;
+        try {
+            while (intBuffer.hasRemaining() && (channel.read(intBuffer) >= 0)) {
+            }
+            if (!intBuffer.hasRemaining()) {
+                intBuffer.rewind();
+                result = intBuffer.asIntBuffer().get(0);
+            }
+        } catch (Exception ignored) {
+        }
+        return result;
+    }
+
+    private static int[] readArrayFromChannel(ReadableByteChannel channel) {
+        int length = readIntFromByteChannel(channel);
+
+        ByteBuffer tmpBuffer = ByteBuffer.allocate(length * INT_BYTES);
+        try {
+            while (tmpBuffer.hasRemaining() && (channel.read(tmpBuffer) >= 0)) {
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        tmpBuffer.rewind();
+        IntBuffer intBuffer = tmpBuffer.asIntBuffer();
+
+        int[] array = new int[length];
+        intBuffer.get(array);
+        return array;
     }
 }


### PR DESCRIPTION
This update alters the NIO calls to make them compatible with Android, which does not always read buffers to completion.

It also alters the routines so that all logical reads are done via a streams 'outermost' wrapper to ensure different data is actually read sequentially.

Additionally, some BufferedInputStream wrappers in some of the deeper methods have been moved up.

These changes have been successfully tested on Android API 22.