### PR TITLE
Builder method to configure custom ResourceResolver

### DIFF
--- a/kuromoji-core/src/main/java/com/atilika/kuromoji/TokenizerBase.java
+++ b/kuromoji-core/src/main/java/com/atilika/kuromoji/TokenizerBase.java
@@ -404,6 +404,18 @@ public abstract class TokenizerBase {
         public abstract <T extends TokenizerBase> T build();
 
         /**
+         * Sets user-defined {@link ResourceResolver}.
+         *
+         * @param resolver {@link com.atilika.kuromoji.util.SimpleResourceResolver SimpleResourceResolver}
+         * or user-defined implementation.
+         * @return this builder
+         */
+        public Builder resolver(ResourceResolver resolver) {
+            this.resolver = resolver;
+            return this;
+        }
+
+        /**
          * Sets an optional user dictionary as an input stream
          * <p>
          * The inpuut stream provided is not closed by this method

--- a/kuromoji-ipadic-neologd/src/main/java/com/atilika/kuromoji/ipadic/neologd/Tokenizer.java
+++ b/kuromoji-ipadic-neologd/src/main/java/com/atilika/kuromoji/ipadic/neologd/Tokenizer.java
@@ -112,6 +112,8 @@ public class Tokenizer extends TokenizerBase {
             readingFeature = DictionaryEntry.READING_FEATURE;
             partOfSpeechFeature = DictionaryEntry.PART_OF_SPEECH_FEATURE;
 
+            resolver = new SimpleResourceResolver(this.getClass());
+
             tokenFactory = new TokenFactory<Token>() {
                 @Override
                 public Token createToken(int wordId,
@@ -210,8 +212,6 @@ public class Tokenizer extends TokenizerBase {
             penalties.add(kanjiPenalty);
             penalties.add(otherPenaltyLengthThreshold);
             penalties.add(otherPenalty);
-
-            resolver = new SimpleResourceResolver(this.getClass());
 
             try {
                 fst = FST.newInstance(resolver);

--- a/kuromoji-ipadic/src/main/java/com/atilika/kuromoji/ipadic/Tokenizer.java
+++ b/kuromoji-ipadic/src/main/java/com/atilika/kuromoji/ipadic/Tokenizer.java
@@ -112,6 +112,8 @@ public class Tokenizer extends TokenizerBase {
             readingFeature = DictionaryEntry.READING_FEATURE;
             partOfSpeechFeature = DictionaryEntry.PART_OF_SPEECH_FEATURE;
 
+            resolver = new SimpleResourceResolver(this.getClass());
+
             tokenFactory = new TokenFactory<Token>() {
                 @Override
                 public Token createToken(int wordId,
@@ -210,8 +212,6 @@ public class Tokenizer extends TokenizerBase {
             penalties.add(kanjiPenalty);
             penalties.add(otherPenaltyLengthThreshold);
             penalties.add(otherPenalty);
-
-            resolver = new SimpleResourceResolver(this.getClass());
 
             try {
                 fst = FST.newInstance(resolver);


### PR DESCRIPTION
This small change adds ability to set custom `ResourceResolver` via `Builder`. Custom resolver will allow loading dictionaries from locations other than Java classpath.