### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,7 @@ install:
 
 script:
   - mvn test -DskipCompileDictionary -pl kuromoji-ipadic -pl kuromoji-unidic -am
+
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION

[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
